### PR TITLE
Added DHCP support on ROACH2s.

### DIFF
--- a/src/tengbe.py
+++ b/src/tengbe.py
@@ -324,6 +324,32 @@ class TenGbe(Memory):
 #        self.parent.write(self.name, self.ip_address.packed(), ip_location)
 #        #self.parent.write_int(self.name, self.port, offset = port_location)
 
+    def dhcp_start(self):
+        """Configure this interface, then start a DHCP client on ALL interfaces"""
+        if self.mac == None:
+            self.mac='0' #TODO get MAC from EEPROM serial number and assign here
+        reply, _ = self.parent.katcprequest(name="tap-start", request_timeout=15, require_ok=True,
+                                            request_args=(self.name, self.name, '0.0.0.0',
+                                                          str(self.port), str(self.mac), ))
+        if reply.arguments[0] != 'ok':
+            raise RuntimeError('Failure starting tap driver instance for %s.' % str(self))
+    
+        reply, _ = self.parent.katcprequest(name="tap-arp-config", request_timeout=1, require_ok=True,
+                                            request_args=(self.name, "mode","0" ))
+        if reply.arguments[0] != 'ok':
+            raise RuntimeError('Failure disabling ARP on %s.' % str(self))
+
+        reply, _ = self.parent.katcprequest(name="tap-dhcp", request_timeout=15, require_ok=True,
+                                            request_args=(self.name, ))
+        if reply.arguments[0] != 'ok':
+            raise RuntimeError('Failure starting DHCP client instance for %s.' % str(self))
+
+        reply, _ = self.parent.katcprequest(name="tap-arp-config", request_timeout=1, require_ok=True,
+                                            request_args=(self.name,"mode","-1" ))
+        if reply.arguments[0] != 'ok':
+            raise RuntimeError('Failure re-enabling ARP on %s.' % str(self))
+
+
     def tap_start(self, restart=False):
         """Program a 10GbE device and start the TAP driver.
         @param self  This object.


### PR DESCRIPTION
Alternative tap-start function, which starts a DHCP client on individual gbe interfaces. ARP is paused while DHCP takes place. Requires romfs roach2-root-katonly-private-arp-config-c0e31f6-2015-06-22.romfs or later.
