### PR TITLE
Metadata timeout fix

### DIFF
--- a/src/katcp_fpga.py
+++ b/src/katcp_fpga.py
@@ -54,7 +54,7 @@ def sendfile(filename, targethost, port, result_queue, timeout=2):
 
 class KatcpFpga(CasperFpga, async_requester.AsyncRequester, katcp.CallbackClient):
 
-    def __init__(self, host, port=7147, timeout=5.0, connect=True):
+    def __init__(self, host, port=7147, timeout=2.0, connect=True):
         async_requester.AsyncRequester.__init__(self, host, self.callback_request, max_requests=100)
         katcp.CallbackClient.__init__(self, host, port, tb_limit=20, timeout=timeout,
                                       logger=LOGGER, auto_reconnect=True)
@@ -482,9 +482,9 @@ class KatcpFpga(CasperFpga, async_requester.AsyncRequester, katcp.CallbackClient
         """
         LOGGER.debug('%s: reading designinfo' % self.host)
         if device is None:
-            reply, informs = self.katcprequest(name='meta', request_timeout=self._timeout, require_ok=True)
+            reply, informs = self.katcprequest(name='meta', request_timeout=5.0, require_ok=True)
         else:
-            reply, informs = self.katcprequest(name='meta', request_timeout=self._timeout, require_ok=True,
+            reply, informs = self.katcprequest(name='meta', request_timeout=5.0, require_ok=True,
                                                request_args=(device, ))
         if reply.arguments[0] != 'ok':
             raise RuntimeError('Could not read meta information from %s' % self.host)

--- a/src/katcp_fpga.py
+++ b/src/katcp_fpga.py
@@ -54,7 +54,7 @@ def sendfile(filename, targethost, port, result_queue, timeout=2):
 
 class KatcpFpga(CasperFpga, async_requester.AsyncRequester, katcp.CallbackClient):
 
-    def __init__(self, host, port=7147, timeout=2.0, connect=True):
+    def __init__(self, host, port=7147, timeout=5.0, connect=True):
         async_requester.AsyncRequester.__init__(self, host, self.callback_request, max_requests=100)
         katcp.CallbackClient.__init__(self, host, port, tb_limit=20, timeout=timeout,
                                       logger=LOGGER, auto_reconnect=True)

--- a/src/tengbe.py
+++ b/src/tengbe.py
@@ -359,7 +359,7 @@ class TenGbe(Memory):
                                                           str(self.port), str(self.mac), ))
         if reply.arguments[0] != 'ok':
             raise RuntimeError('%s: failure starting tap driver.' % self.name)
-    
+
         reply, _ = self.parent.katcprequest(name="tap-arp-config", request_timeout=1,
                                             require_ok=True,
                                             request_args=(self.name, "mode", "0"))


### PR DESCRIPTION
This fix will hopefully, sort out the metadata request timeout.

Traceback (most recent call last):
File "/usr/lib/python2.7/threading.py", line 552, in __bootstrap_inner
self.run()
File "/usr/lib/python2.7/threading.py", line 505, in run
self.__target(self.__args, *self.__kwargs)
File "/home/mmphego/src/casperfpga/casperfpga/utils.py", line 199, in jobfunc
rv = target_function0
File "/home/mmphego/src/casperfpga/casperfpga/utils.py", line 178, in dofunc
rv = eval('fpga.%s' % target_function[0])(args, *kwargs)
File "/home/mmphego/src/casperfpga/casperfpga/katcp_fpga.py", line 538, in get_system_information
device_dict = self._read_design_info_from_host()
File "/home/mmphego/src/casperfpga/casperfpga/katcp_fpga.py", line 485, in _read_design_info_from_host
reply, informs = self.katcprequest(name='meta', request_timeout=self._timeout, require_ok=True)
File "/home/mmphego/src/casperfpga/casperfpga/katcp_fpga.py", line 125, in katcprequest
(request.name, self.host, request, reply))
KatcpRequestError: Request meta on host roach020A0A failed.
Request: ?meta
Reply: !meta fail Request_meta_timed_out_after_2.069240_seconds.
