### PR TITLE
Refactor sdram prog code for readability

### DIFF
--- a/debug/skarab_testprogamming.py
+++ b/debug/skarab_testprogamming.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+"""
+Go through the SKARABs in dnsmasq and try to program them many times.
+Collect stats about which could and could not be programmed.
+"""
+
+from casperfpga import skarab_fpga
+
+from corr2 import utils as corr2utils
+
+dnsmasq = ''
+
+hosts, lease_filename = corr2utils.hosts_from_dhcp_leases(host_pref='')
+print 'Found %i roaches in %s.' % (len(hosts), lease_filename)
+for host in hosts:
+    print '\t', host
+
+results = {host: [0, 0] for host in hosts}
+loops = 10
+loopctr = 0
+while loopctr < loops:
+    print 'loop:', loopctr
+    for host in hosts:
+        print '\t', host,
+        try:
+            f = skarab_fpga.SkarabFpga(host)
+            print f.get_firmware_version(),
+            print f.get_embedded_software_ver(),
+            res = f.upload_to_ram_and_program(
+                '/home/paulp/bofs/spead_test_2017-4-6_1412.fpg')
+            if not res:
+                raise RuntimeError
+            results[host][0] += 1
+            print 'pass'
+        except Exception as e:
+            results[host][1] += 1
+            print 'fail'
+    loopctr += 1
+print results
+
+# end

--- a/scripts/casperfpga_deprogram.py
+++ b/scripts/casperfpga_deprogram.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-__author__ = 'paulp'
-
 import argparse
 
 from casperfpga import katcp_fpga
 from casperfpga import dcp_fpga
 
-parser = argparse.ArgumentParser(description='Program an FPGA.',
-                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser = argparse.ArgumentParser(
+    description='Program an FPGA.',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument(dest='hostname', type=str, action='store',
                     help='the hostname of the FPGA')
-parser.add_argument('--comms', dest='comms', action='store', default='katcp', type=str,
-                    help='katcp (default) or dcp?')
+parser.add_argument('--comms', dest='comms', action='store',
+                    default='katcp', type=str, help='katcp (default) or dcp?')
 parser.add_argument('--loglevel', dest='log_level', action='store', default='',
-                    help='log level to use, default None, options INFO, DEBUG, ERROR')
+                    help='log level to use, default None, '
+                         'options INFO, DEBUG, ERROR')
 args = parser.parse_args()
 
 if args.comms == 'katcp':

--- a/src/skarab_fpga.py
+++ b/src/skarab_fpga.py
@@ -428,7 +428,7 @@ class SkarabFpga(CasperFpga):
         # clear sdram programmed flag
         self.__sdram_programmed = False
         # if fpg file used, get design information
-        if self.prog_info['last_uploaded'].split('.')[1] == 'fpg':
+        if os.path.splitext(self.prog_info['last_uploaded'])[1] == '.fpg':
             super(SkarabFpga, self).get_system_information(
                 filename=self.prog_info['last_uploaded'])
             self.__create_memory_map()


### PR DESCRIPTION
Refactor SDRAM programming code for readability.

@tyronevb - The goal was readability, particularly of the sdram_reconfigure function. Instead of passing largely the same long list of args to the function, use defaults and then set specific keyword args. Then you can instantly see what the call is doing. What do you think?