### PR TITLE
Check for InvalidOpcode response from SKARAB

### DIFF
--- a/src/skarab_fpga.py
+++ b/src/skarab_fpga.py
@@ -1123,6 +1123,13 @@ class SkarabFpga(CasperFpga):
                     response_payload, address = data
                     LOGGER.debug('Response = %s' % repr(response_payload))
                     LOGGER.debug('Response length = %d' % len(response_payload))
+
+                    # check the opcode of the response i.e. first two bytes
+                    if response_payload[:2] == '\xff\xff':
+                        # SKARAB received an unsupported opcode
+                        errmsg = 'SKARAB received unsupported opcode'
+                        raise SkarabSendPacketError(errmsg)
+
                     response_payload = self.unpack_payload(
                         response_payload, response_type,
                         number_of_words, pad_words)


### PR DESCRIPTION
@paulprozesky A small addition checking for a new response coming from the microblaze in the event of an unsupported request opcode.