### PR TITLE
Check response packet size before unpacking

### DIFF
--- a/src/casperfpga.py
+++ b/src/casperfpga.py
@@ -19,6 +19,16 @@ from transport_dummy import DummyTransport
 
 LOGGER = logging.getLogger(__name__)
 
+# define a custom log level between DEBUG and INFO
+PDEBUG = 15
+logging.addLevelName(PDEBUG, "PDEBUG")
+
+
+def pdebug(self, message, *args, **kwargs):
+    if self.isEnabledFor(PDEBUG):
+        self.log(PDEBUG, message, *args, **kwargs)
+logging.Logger.pdebug = pdebug
+
 # known CASPER memory-accessible devices and their associated
 # classes and containers
 CASPER_MEMORY_DEVICES = {


### PR DESCRIPTION
We now first check the response packet size before unpacking. Also added
a custom debug level and debug architecture to allow debugging of the
case where response packets of the incorrect size are being received.