### PR TITLE
Adding compiling on MacOSX using virtualenv

### DIFF
--- a/progska/netc.c
+++ b/progska/netc.c
@@ -223,27 +223,54 @@ int net_connect(char *name, int port, int flags)
       fprintf(stderr,"connect: cannot set keepalive socket option\n");
       return -1;
     }
-#ifdef TCP_KEEPIDLE
+
+
+    #ifdef __APPLE__
+      #ifdef TCP_KEEPIDLE
+      option = 10;
+      if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &option, sizeof(option)) < 0){
+        fprintf(stderr,"connect: cannot set keepalive socket option\n");
+        return -1;
+      }
+      #endif
+      #ifdef TCP_KEEPINTVL
+      option = 10;
+      if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &option, sizeof(option)) < 0){
+        fprintf(stderr,"connect: cannot set keepalive socket option\n");
+        return -1;
+      }
+      #endif
+      #ifdef TCP_KEEPCNT
+      option = 3;
+      if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &option, sizeof(option)) < 0){
+        fprintf(stderr,"connect: cannot set keepalive socket option\n");
+        return -1;
+      }
+      #endif
+  #elif __linux__
+    #ifdef TCP_KEEPIDLE
     option = 10;
     if (setsockopt(fd, SOL_TCP, TCP_KEEPIDLE, &option, sizeof(option)) < 0){
       fprintf(stderr,"connect: cannot set keepalive socket option\n");
       return -1;
     }
-#endif
-#ifdef TCP_KEEPINTVL
+    #endif
+    #ifdef TCP_KEEPINTVL
     option = 10;
     if (setsockopt(fd, SOL_TCP, TCP_KEEPINTVL, &option, sizeof(option)) < 0){
       fprintf(stderr,"connect: cannot set keepalive socket option\n");
       return -1;
     }
-#endif
-#ifdef TCP_KEEPCNT
+    #endif
+    #ifdef TCP_KEEPCNT
     option = 3;
     if (setsockopt(fd, SOL_TCP, TCP_KEEPCNT, &option, sizeof(option)) < 0){
       fprintf(stderr,"connect: cannot set keepalive socket option\n");
       return -1;
     }
-#endif
+    #endif
+
+  #endif
   }
 
   len = sizeof(struct sockaddr_in);

--- a/progska/progska.c
+++ b/progska/progska.c
@@ -403,7 +403,13 @@ static int perform_send(struct total *t, struct skarab *s)
   t->t_address.sin_addr.s_addr = s->s_addr;
   /* t->t_address.sin_port */
 
+  #ifdef __APPLE__
+  wr = sendmsg(t->t_fd, &(t->t_message), 0            | MSG_DONTWAIT);
+  #elif __linux__
   wr = sendmsg(t->t_fd, &(t->t_message), MSG_NOSIGNAL | MSG_DONTWAIT);
+  #else 
+  perror("Unknown platform");
+  #endif
 
   if(wr < 0){
     switch(errno){


### PR DESCRIPTION
- Remove useless NOSIGNAL flags : Those signals are useless and causes problems on darwin (BSD) compilation.Actually on recv, the flag is ignored on Linux, and on send, it should not be necessary if we do not write on a closed socket.
- IPPROTO_TCP seems to be equivalent. (Actually on both Linux and OSX, but this diff is smaller).