### PR TITLE
Add command to allow SKARABs to leave multicast groups

### DIFF
--- a/src/skarab_definitions.py
+++ b/src/skarab_definitions.py
@@ -134,6 +134,7 @@ GET_VOLTAGE_LOGS = 0x0059
 GET_FAN_CONT_LOGS = 0x005B
 CLEAR_FAN_CONT_LOGS = 0x005D
 RESET_DHCP_SM = 0x005F
+MULTICAST_LEAVE_GROUP = 0x0061
 
 # FOR VIRTEX FLASH RECONFIG
 DEFAULT_START_ADDRESS = 0x3000000
@@ -1817,6 +1818,24 @@ class ResetDHCPStateMachineResp(Response):
         super(ResetDHCPStateMachineResp, self).__init__(command_id, seq_num)
         self.packet['link_id'] = link_id
         self.packet['reset_error'] = reset_error
+        self.packet['padding'] = padding
+
+
+class MulticastLeaveGroupReq(Command):
+    def __init__(self, link_id):
+        super(MulticastLeaveGroupReq, self).__init__(MULTICAST_LEAVE_GROUP)
+        self.expect_response = True
+        self.response = MulticastLeaveGroupResp
+        self.num_response_words = 11
+        self.pad_words = 7
+        self.packet['link_id'] = link_id
+
+
+class MulticastLeaveGroupResp(Response):
+    def __init__(self, command_id, seq_num, link_id, success, padding):
+        super(MulticastLeaveGroupResp, self).__init__(command_id, seq_num)
+        self.packet['link_id'] = link_id
+        self.packet['success'] = success
         self.packet['padding'] = padding
 
 

--- a/src/transport_skarab.py
+++ b/src/transport_skarab.py
@@ -3729,6 +3729,27 @@ class SkarabTransport(Transport):
                 error_dictionary[response.packet['reset_error']])
             raise SkarabUnknownDeviceError(err)
 
+    def leave_multicast_group(self, link_id=1, timeout=None, retries=None):
+        """
+        SKARAB to issue IGMP leave request to exit a multicast group.
+        :param link_id:
+        :param timeout:
+        :param retries:
+        :return: True if leave request successful, False if not
+        """
+
+        request = sd.MulticastLeaveGroupReq(link_id)
+
+        response = self.send_packet(request, timeout=timeout, retries=retries)
+
+        # check if the request was successful
+        if response.packet['success']:
+            self.logger.info('{host} left multicast group'.format(host=self.host))
+            return True
+        else:
+            self.logger.error('{host} failed to leave multicast group'.format(host=self.host))
+            return False
+
     # TODO: only declare this function once! Will have to be global
     @staticmethod
     def _sign_extend(value, bits):


### PR DESCRIPTION
Adds the 'leave_multicast_group' command that allows a SKARAB to
unsubscribe from a previously subscribed to multicast group. Only takes
'interface_id' or 'link_id' as an argument. For the single 40GbE link,
this defaults to 1.

JIRA: ST-218