### PR TITLE
Clean up upload_to_ram_and_program method

### DIFF
--- a/src/transport_itpm.py
+++ b/src/transport_itpm.py
@@ -271,7 +271,8 @@ class ItpmTransport(Transport):
         pass
 
     def upload_to_ram_and_program(self, filename, port=-1, timeout=10,
-                                  wait_complete=True, skip_verification=False):
+                                  wait_complete=True, skip_verification=False,
+                                  **kwargs):
         """
         Upload an FPG file to RAM and then program the FPGA.
         :param filename: the file to upload

--- a/src/transport_katcp.py
+++ b/src/transport_katcp.py
@@ -523,7 +523,7 @@ class KatcpTransport(Transport, katcp.CallbackClient):
 
     def upload_to_ram_and_program(self, filename, port=-1, timeout=10,
                                   wait_complete=True,
-                                  skip_verification=False):
+                                  skip_verification=False, **kwargs):
         """
         Upload an FPG file to RAM and then program the FPGA.
 

--- a/src/transport_skarab.py
+++ b/src/transport_skarab.py
@@ -674,7 +674,8 @@ class SkarabTransport(Transport):
             return False, '0.0'
 
     def upload_to_ram_and_program(self, filename, port=-1, timeout=60,
-                                  wait_complete=True, skip_verification=False, chunk_size=1988):
+                                  wait_complete=True, skip_verification=False,
+                                  **kwargs):
         """
         Uploads an FPGA image to the SDRAM, and triggers a reboot to boot
         from the new image.
@@ -689,13 +690,18 @@ class SkarabTransport(Transport):
         :param skip_verification - do not verify the image after upload
         :return: Boolean - True/False - Succes/Fail
         """
-        #print('skarab_transport')
-        print(chunk_size)
+
+        # check if a chunk size was specified, else default to 1988
+        if 'chunk_size' in kwargs.keys():
+            chunk_size = kwargs['chunk_size']
+        else:
+            # default to a chunk size of 1988
+            chunk_size = 1988
+
         try:
             upload_time = self.upload_to_ram(filename, not skip_verification, chunk_size)
-            #print("completed fine")
+
         except:
-            #print("failed to program")
             self.logger.error('Failed to program.')
             raise
         if not wait_complete:

--- a/src/transport_tapcp.py
+++ b/src/transport_tapcp.py
@@ -266,7 +266,8 @@ class TapcpTransport(Transport):
 
         return head_loc, prog_loc
 
-    def upload_to_ram_and_program(self, filename, port=None, timeout=None, wait_complete=True):
+    def upload_to_ram_and_program(self, filename, port=None, timeout=None,
+                                  wait_complete=True, **kwargs):
         USER_FLASH_LOC = 0x800000
         sector_size = 0x10000
         # Flash writes can take a long time, due to ~1s erase cycle


### PR DESCRIPTION
Cleaned up the upload_to_ram_and_program method. If programming a board
fails, we no longer populate the system information. Also cleaned up the
passing of unique parameters to the transport layers. e.g. the
chunk_size parameter for skarab. This can be passed as a kwarg to
upload_to_ram_and_program and is handled appropriately in the underlying
transport layer.

CBFTASKS-803