### PR TITLE
Gbe no local state

### DIFF
--- a/src/gbe.py
+++ b/src/gbe.py
@@ -20,9 +20,6 @@ class Gbe(object):
         self.name = name
         self.address = address
         self.length_bytes = length_bytes
-        self.mac = None
-        self.ip_address = None
-        self.port = None
         self.fullname = self.parent.host + ':' + self.name
         self.block_info = device_info
         self.process_device_info(device_info)
@@ -33,6 +30,18 @@ class Gbe(object):
         # TODO
         # if self.parent.is_connected():
         #     self._check()
+
+    @property
+    def mac(self):
+        return None
+
+    @property
+    def ip_address(self):
+        return None
+
+    @property
+    def port(self):
+        return None
 
     @classmethod
     def from_device_info(cls, parent, device_name, device_info, memorymap_dict, **kwargs):
@@ -99,7 +108,6 @@ class Gbe(object):
         if mac is None or ip_address is None or port is None:
             raise ValueError('%s: 10Gbe interface must '
                              'have mac, ip and port.' % self.fullname)
-        self.setup(mac, ip_address, port)
 
     def setup(self, mac, ipaddress, port):
         """
@@ -109,9 +117,10 @@ class Gbe(object):
         :param ipaddress: String or Integer input
         :param port: String or Integer input
         """
-        self.mac = Mac(mac)
-        self.ip_address = IpAddress(ipaddress)
-        self.port = port if isinstance(port, int) else int(port)
+        raise NotImplementedError('This is no longer required as the mac, '
+                                  'ip_address and port are no longer stored '
+                                  'as attributes. These values are retrieved '
+                                  'from the processing node when required.')
 
     def post_create_update(self, raw_device_info):
         """

--- a/src/onegbe.py
+++ b/src/onegbe.py
@@ -93,6 +93,18 @@ class OneGbe(Memory, Gbe):
         Gbe.__init__(self, parent, name, address, length_bytes, device_info)
         self.memmap_compliant = self._check_memmap_compliance()
 
+    @property
+    def mac(self):
+        return self.get_gbe_core_details()['mac']
+
+    @property
+    def ip_address(self):
+        return self.get_gbe_core_details()['ip']
+
+    @property
+    def port(self):
+        return self.get_gbe_core_details()['fabric_port']
+
     def _check_memmap_compliance(self):
         """
         Look at the first word of the core's memory map and try to
@@ -162,9 +174,9 @@ class OneGbe(Memory, Gbe):
         """
         Configure this interface, then start a DHCP client on ALL interfaces.
         """
-        if self.mac is None:
+        #if self.mac is None:
             # TODO get MAC from EEPROM serial number and assign here
-            self.mac = '0'
+            # self.mac = '0'
         reply, _ = self.parent.transport.katcprequest(
             name='tap-start', request_timeout=5,
             require_ok=True,

--- a/src/tengbe.py
+++ b/src/tengbe.py
@@ -93,6 +93,18 @@ class TenGbe(Memory, Gbe):
         Gbe.__init__(self, parent, name, address, length_bytes, device_info)
         self.memmap_compliant = self._check_memmap_compliance()
 
+    @property
+    def mac(self):
+        return self.get_gbe_core_details()['mac']
+
+    @property
+    def ip_address(self):
+        return self.get_gbe_core_details()['ip']
+
+    @property
+    def port(self):
+        return self.get_gbe_core_details()['fabric_port']
+
     def _check_memmap_compliance(self):
         """
         Look at the first word of the core's memory map and try to
@@ -162,9 +174,9 @@ class TenGbe(Memory, Gbe):
         """
         Configure this interface, then start a DHCP client on ALL interfaces.
         """
-        if self.mac is None:
+        #if self.mac is None:
             # TODO get MAC from EEPROM serial number and assign here
-            self.mac = '0'
+            #self.mac = '0'
         reply, _ = self.parent.transport.katcprequest(
             name='tap-start', request_timeout=5,
             require_ok=True,


### PR DESCRIPTION
The _ip_ address, _port_ and _mac address_ of the processing nodes were previously stored locally in class attributes. This change sees these attributes call methods that retrieve this information directly from the processing node. All other methods that rely on these attributes behave as expected without modification.

The fortygbe, onegbe and tengbe core classes were all refactored to support this. Only the fortygbe has been tested.

Resolved: CBFTASKS-821 (jira)