### PR TITLE
Fix parent-level upload_to_ram_and_program method

### DIFF
--- a/src/casperfpga.py
+++ b/src/casperfpga.py
@@ -328,6 +328,10 @@ class CasperFpga(object):
                 self._detect_little_endianness()
             except:
                 pass
+            
+            return True
+        else:
+            return False
 
     def is_connected(self, **kwargs):
         """


### PR DESCRIPTION
The parent-level upload_to_ram_and_program method wasn't returning the
expected bool to indicate whether programming was successful or not.
This was implemented correctly in the lower-level methods and was just
not being returned by the parent method.

Addresses Jira: ST-243